### PR TITLE
Fixed (used) bag space value when bots have other bags equipped.

### DIFF
--- a/playerbot/strategy/values/StatsValues.cpp
+++ b/playerbot/strategy/values/StatsValues.cpp
@@ -151,7 +151,6 @@ uint8 BagSpaceValue::Calculate()
             totalused++;
     }
 
-    uint32 totalfree = 16 - totalused;
     for (uint8 bag = INVENTORY_SLOT_BAG_START; bag < INVENTORY_SLOT_BAG_END; ++bag)
     {
         const Bag* const pBag = (Bag*) bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bag);
@@ -161,7 +160,7 @@ uint8 BagSpaceValue::Calculate()
             if (pBagProto->Class == ITEM_CLASS_CONTAINER && pBagProto->SubClass == ITEM_SUBCLASS_CONTAINER)
             {
                 total += pBag->GetBagSize();
-                totalfree += pBag->GetFreeSlots();
+				totalused += pBag->GetBagSize() - pBag->GetFreeSlots();
             }
         }
 


### PR DESCRIPTION
Variable totalfree  was used for (non backpack) bags but not for return value.

Switched to use totalused like for backpack.

Perhaps value should be renamed to "used bag space" or inverted to (free) "bag space" to avoid confusion.